### PR TITLE
Gui session

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,13 @@ if(RUN_TESTS)
 endif()
 
 if(DEBUG)
-  add_definitions("-DDEBUG -g")
+  add_definitions("-g")
 endif()
+
+if(PRINT_DEBUG)
+  add_definitions("-DDEBUG")
+endif()
+
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
   set (CMAKE_CXX_FLAGS "-Wno-pointer-sign")
 endif()

--- a/src/app/app.c
+++ b/src/app/app.c
@@ -26,22 +26,29 @@
 
 #define END_LISTEN -1
 #define SESSION_INTERACTION "session_interaction"
+#define RECEIVE_GUID "receive_guid"
 
-static int get_session_interaction_path(char *path) {
+static int get_tmp_path(char *path, char *filename) {
   int size = 0;
   size += strlen(P_tmpdir);
   int has_end_slash = (P_tmpdir[strlen(P_tmpdir)] == '/');
   if (has_end_slash) {
     size++;
   }
-  size += strlen(SESSION_INTERACTION);
+  size += strlen(filename);
   memset(path, 0, size);
   strcpy(path, P_tmpdir);
   if (! has_end_slash) {
     strcat(path, "/");
   }
-  strcat(path, SESSION_INTERACTION);
+  strcat(path, filename);
   return size;
+}
+static int get_session_interaction_path(char *path) {
+  return get_tmp_path(path, SESSION_INTERACTION);
+}
+static int get_recieve_guid_path(char *path) {
+  return get_tmp_path(path, RECEIVE_GUID);
 }
 typedef struct {
   int abort;

--- a/src/app/app.c
+++ b/src/app/app.c
@@ -333,18 +333,22 @@ session *app_accept_chat(app_context_t *context) {
   jnx_unix_socket *us = jnx_unix_stream_socket_create(sockpath);
   jnx_unix_stream_socket_send(us, (jnx_uint8 *) "accept",
       strlen("accept"));
-  jnx_guid *session_guid = calloc(1, sizeof(jnx_guid));
-  read(us->socket, (void *) session_guid, sizeof(jnx_guid));
-  JNXCHECK(session_guid);
+  jnx_guid session_guid;
+  read(us->socket, (void *) &session_guid, sizeof(jnx_guid));
+#ifdef DEBUG
+  char *guid_str;
+  jnx_guid_to_string(&session_guid, &guid_str);
+  printf("[DEBUG] Received SessionGUID = %s\n", guid_str);
+  free(guid_str);
+#endif
   jnx_unix_socket_destroy(&us);
 
   session *osession = NULL;
   while (SESSION_STATE_NOT_FOUND 
       == session_service_fetch_session(context->session_serv,
-            session_guid, &osession)) {
+            &session_guid, &osession)) {
     sleep(1);
   }
-  free(session_guid);
   while (osession->secure_comms_fd == 0) {
     sleep(1);
   }

--- a/src/app/app.c
+++ b/src/app/app.c
@@ -89,9 +89,9 @@ void unpair_session_from_gui(session *s, void *gui_context) {
 }
 void app_create_gui_session(session *s) {
   gui_context_t *c = gui_create(s);
-  pair_session_with_gui(s, (void *) c);
-  read_loop((void *) c);
-  unpair_session_from_gui(s, (void *) c);
+  pair_session_with_gui(s, (void *)c);
+  read_loop((void *)c);
+  unpair_session_from_gui(s, (void *)c);
 }
 int is_equivalent(char *command, char *expected) {
   if (strcmp(command, expected) == 0) {

--- a/src/app/app.c
+++ b/src/app/app.c
@@ -83,10 +83,15 @@ void pair_session_with_gui(session *s, void *gui_context) {
   s->gui_context = gui_context;
   s->session_callback = gui_receive_message;
 }
+void unpair_session_from_gui(session *s, void *gui_context) {
+  s->gui_context = NULL;
+  s->session_callback = NULL;
+}
 void app_create_gui_session(session *s) {
   gui_context_t *c = gui_create(s);
   pair_session_with_gui(s, (void *) c);
   read_loop((void *) c);
+  unpair_session_from_gui(s, (void *) c);
 }
 int is_equivalent(char *command, char *expected) {
   if (strcmp(command, expected) == 0) {

--- a/src/app/app.c
+++ b/src/app/app.c
@@ -333,16 +333,18 @@ session *app_accept_chat(app_context_t *context) {
   jnx_unix_socket *us = jnx_unix_stream_socket_create(sockpath);
   jnx_unix_stream_socket_send(us, (jnx_uint8 *) "accept",
       strlen("accept"));
-  jnx_guid session_guid;
-  read(us->socket, (void *) &session_guid, sizeof(jnx_guid));
+  jnx_guid *session_guid = calloc(1, sizeof(jnx_guid));
+  read(us->socket, (void *) session_guid, sizeof(jnx_guid));
+  JNXCHECK(session_guid);
   jnx_unix_socket_destroy(&us);
 
   session *osession = NULL;
   while (SESSION_STATE_NOT_FOUND 
       == session_service_fetch_session(context->session_serv,
-            &session_guid, &osession)) {
+            session_guid, &osession)) {
     sleep(1);
   }
+  free(session_guid);
   while (osession->secure_comms_fd == 0) {
     sleep(1);
   }

--- a/src/app/app.c
+++ b/src/app/app.c
@@ -30,9 +30,16 @@
 static int get_session_interaction_path(char *path) {
   int size = 0;
   size += strlen(P_tmpdir);
+  int has_end_slash = (P_tmpdir[strlen(P_tmpdir)] == '/');
+  if (has_end_slash) {
+    size++;
+  }
   size += strlen(SESSION_INTERACTION);
-  memset(path, 0, size + 1);
+  memset(path, 0, size);
   strcpy(path, P_tmpdir);
+  if (! has_end_slash) {
+    strcat(path, "/");
+  }
   strcat(path, SESSION_INTERACTION);
   return size;
 }

--- a/src/app/app.h
+++ b/src/app/app.h
@@ -21,6 +21,7 @@
 
 #include <jnxc_headers/jnxhash.h>
 #include <jnxc_headers/jnxvector.h>
+#include <jnxc_headers/jnxunixsocket.h>
 #include "../net/discovery.h"
 #include "../net/auth_comms.h"
 #include "../session/session_service.h"
@@ -53,5 +54,7 @@ void app_create_gui_session(session *s);
 void app_list_active_peers(app_context_t *context);
 peer *app_peer_from_input(app_context_t *context,char *param);
 void app_initiate_handshake(app_context_t *context,session *s);
-int app_accept_or_reject_session(discovery_service *ds, jnx_guid *g);
+int app_accept_or_reject_session(discovery_service *ds,
+    jnx_guid *ig, jnx_guid *sg);
+session *app_accept_chat(app_context_t *context);
 #endif // __APP_H__

--- a/src/app/main.c
+++ b/src/app/main.c
@@ -57,6 +57,7 @@ int run_app(app_context_t *context) {
       case CMD_ACCEPT_SESSION:
         osession = app_accept_chat(context);
         app_create_gui_session(osession);
+        printf("Exiting GUI from accept.\n");
         break;
       case CMD_REJECT_SESSION:
         break;
@@ -92,6 +93,7 @@ int run_app(app_context_t *context) {
             sleep(1);
           }
           app_create_gui_session(s);
+          printf("Exiting GUI from session.\n");
         }else {
           printf("Session could not be started.\nDid you spell your target%s",
               " username correctly?\n");

--- a/src/app/main.c
+++ b/src/app/main.c
@@ -52,8 +52,11 @@ int run_app(app_context_t *context) {
     jnx_size s = getline(&cmd_string,&read_bytes,stdin);
     char *param = NULL;
     jnx_vector *active_peers = NULL;
+    session *osession;
     switch(app_code_for_command_with_param(cmd_string,read_bytes,&param)) {
       case CMD_ACCEPT_SESSION:
+        osession = app_accept_chat(context);
+        app_create_gui_session(osession);
         break;
       case CMD_REJECT_SESSION:
         break;
@@ -69,7 +72,7 @@ int run_app(app_context_t *context) {
 
           peer *local_peer = peerstore_get_local_peer(context->discovery->peers);
           if(strcmp(remote_peer->host_address,local_peer->host_address) == 0) {
-            printf("You cannot start a session with yourself.\n");
+            printf("You cannot t a session with yourself.\n");
             break;
           }
           printf("Found peer.\n");
@@ -80,7 +83,7 @@ int run_app(app_context_t *context) {
           /* create session */
           session_service_create_session(context->session_serv,&s);
           /* link our peers to our session information */
-          session_service_link_sessions(context->session_serv,&(*s).session_guid,
+          session_service_link_sessions(context->session_serv,&s->session_guid,
               local_peer,remote_peer);
 
           /* async handshake */
@@ -90,8 +93,8 @@ int run_app(app_context_t *context) {
           }
           app_create_gui_session(s);
         }else {
-          printf("Session could not be started.\nDid you spell your target \
-              username correctly?\n");
+          printf("Session could not be started.\nDid you spell your target%s",
+              " username correctly?\n");
         }
         if(param) {
           free(param);

--- a/src/gui/gui.c
+++ b/src/gui/gui.c
@@ -159,7 +159,7 @@ void *read_loop(void *data) {
     }
   }
   session_disconnect(context->s);
-  display_alert_message(context->s, "The chat has terminated."); 
+  display_alert_message(context, "The chat has terminated."); 
   gui_destroy(context);
   return NULL;
 }

--- a/src/gui/gui.c
+++ b/src/gui/gui.c
@@ -22,6 +22,7 @@
 #define COL_LOGO   1
 #define COL_LOCAL  2
 #define COL_REMOTE 3
+#define COL_ALERT  4
 
 static pthread_mutex_t output_mutex;
 static pthread_cond_t output_cond;
@@ -36,6 +37,7 @@ void init_colours() {
   init_pair(COL_LOGO, COLOR_WHITE, COLOR_BLUE);
   init_pair(COL_LOCAL, COLOR_WHITE, COLOR_BLACK);
   init_pair(COL_REMOTE, COLOR_GREEN, COLOR_BLACK);
+  init_pair(COL_ALERT, COLOR_RED, COLOR_BLACK);
 }
 void show_prompt(ui_t *ui) {
   wmove(ui->prompt, 1, 1);
@@ -117,6 +119,9 @@ void display_remote_message(gui_context_t *c, char *msg) {
   display_message(c->ui, msg, COL_REMOTE);
   free(msg);
 }
+void display_alert_message(gui_context_t *c, char *msg) {
+  display_message(c->ui, msg, COL_ALERT);
+}
 void signal_message() {
   int retval;
   if ((retval = pthread_cond_signal(&output_cond)) != 0) {
@@ -149,7 +154,6 @@ void *read_loop(void *data) {
         display_local_message(context, msg);
       }
       else {
-        display_local_message(context, "!!! The chat has finished !!!");
         break;
       }
     }
@@ -164,6 +168,8 @@ void gui_receive_message(void *gc, jnx_guid *session_guid, jnx_char *message) {
     display_remote_message(c, message);
   }
   else {
+    display_alert_message(c, message);
+    sleep(2);
     gui_destroy(c);
   }
 }

--- a/src/gui/gui.c
+++ b/src/gui/gui.c
@@ -156,21 +156,3 @@ void gui_receive_message(void *gc, jnx_guid *session_guid, jnx_char *message) {
   gui_context_t *c = (gui_context_t *) gc;
   display_remote_message(c, message);
 }
-int output_next_message_in_context(gui_context_t *context) {
-  pthread_mutex_lock(&output_mutex);	
-  wait_for_message();
-  ui_t *cui = context->ui;
-  char *msg = context->msg;
-  if (strcmp(msg, ":q") == 0) {
-    pthread_mutex_unlock(&output_mutex);
-    return -1;
-  }
-  else if (strncmp(msg, "r/", 2) == 0) {
-    display_remote_message(context, msg);
-  }
-  else {
-    display_local_message(context, msg);
-  }
-  pthread_mutex_unlock(&output_mutex);
-  return 0;
-}

--- a/src/gui/gui.c
+++ b/src/gui/gui.c
@@ -154,7 +154,6 @@ void *read_loop(void *data) {
 }
 void gui_receive_message(void *gc, jnx_guid *session_guid, jnx_char *message) {
   gui_context_t *c = (gui_context_t *) gc;
-  printf("[DEBUG] %s", message);
   display_remote_message(c, message);
 }
 int output_next_message_in_context(gui_context_t *context) {

--- a/src/gui/gui.c
+++ b/src/gui/gui.c
@@ -34,7 +34,7 @@ void init_colours() {
   init_pair(COL_LOGO, COLOR_WHITE, COLOR_BLUE);
   init_pair(COL_LOCAL, COLOR_WHITE, COLOR_BLACK);
   init_pair(COL_REMOTE, COLOR_GREEN, COLOR_BLACK);
-  init_pair(COL_ALERT, COLOR_RED, COLOR_BLACK);
+  init_pair(COL_ALERT, COLOR_YELLOW, COLOR_BLACK);
 }
 void show_prompt(ui_t *ui) {
   wmove(ui->prompt, 1, 1);
@@ -139,9 +139,7 @@ void *read_loop(void *data) {
     }
   }
   session_disconnect(context->s);
-  gui_unpair_session(context);
-  display_alert_message(context, "The chat has terminated."); 
-  gui_destroy(context);
+  display_alert_message(context, "The chat has terminated. Type :q to end the session."); 
   return NULL;
 }
 void gui_receive_message(void *gc, jnx_guid *session_guid, jnx_char *message) {

--- a/src/gui/gui.c
+++ b/src/gui/gui.c
@@ -140,7 +140,9 @@ void send_message_to_context(gui_context_t *context, char *message) {
   pthread_mutex_unlock(&output_mutex);
   signal_message();
 }
-
+static void gui_unpair_session(gui_context_t *c) {
+  c->s->session_callback = NULL;
+}
 void *read_loop(void *data) {
   gui_context_t *context = (gui_context_t *) data;
   while(TRUE) {
@@ -159,6 +161,7 @@ void *read_loop(void *data) {
     }
   }
   session_disconnect(context->s);
+  gui_unpair_session(context);
   display_alert_message(context, "The chat has terminated."); 
   gui_destroy(context);
   return NULL;
@@ -169,6 +172,7 @@ void gui_receive_message(void *gc, jnx_guid *session_guid, jnx_char *message) {
     display_remote_message(c, message);
   }
   else {
+    gui_unpair_session(c);
     display_alert_message(c, message);
     sleep(2);
     gui_destroy(c);

--- a/src/gui/gui.c
+++ b/src/gui/gui.c
@@ -139,7 +139,8 @@ void *read_loop(void *data) {
     }
   }
   session_disconnect(context->s);
-  display_alert_message(context, "The chat has terminated. Type :q to end the session."); 
+  gui_unpair_session(context);
+  gui_destroy(context);
   return NULL;
 }
 void gui_receive_message(void *gc, jnx_guid *session_guid, jnx_char *message) {
@@ -151,9 +152,6 @@ void gui_receive_message(void *gc, jnx_guid *session_guid, jnx_char *message) {
     display_remote_message(c, message);
   }
   else {
-    gui_unpair_session(c);
     display_alert_message(c, message);
-    sleep(2);
-    gui_destroy(c);
   }
 }

--- a/src/gui/gui.c
+++ b/src/gui/gui.c
@@ -159,6 +159,7 @@ void *read_loop(void *data) {
     }
   }
   session_disconnect(context->s);
+  display_alert_message(context->s, "The chat has terminated."); 
   gui_destroy(context);
   return NULL;
 }

--- a/src/gui/gui.c
+++ b/src/gui/gui.c
@@ -60,7 +60,7 @@ gui_context_t *gui_create(session *s) {
   display_logo();
   ui->screen = newwin(LINES - 6, COLS - 1, 1, 1);
   scrollok(ui->screen, TRUE);
-//  box(ui->screen, 0, 0);
+  //  box(ui->screen, 0, 0);
   wborder(ui->screen, '|', '|', '-', '-', '+', '+', '+', '+');
   ui->next_line = 1;
   wrefresh(ui->screen);
@@ -141,18 +141,29 @@ void *read_loop(void *data) {
   while(TRUE) {
     char *msg = get_message(context);
     if (strcmp(msg, ":q") == 0) {
-      session_disconnect(context->s);
-      gui_destroy(context);
       break;
     }
     else {
       session_state res = session_message_write(context->s, msg);
-      display_local_message(context, msg);
+      if (SESSION_STATE_OKAY == res) {
+        display_local_message(context, msg);
+      }
+      else {
+        display_local_message(context, "!!! The chat has finished !!!");
+        break;
+      }
     }
   }
+  session_disconnect(context->s);
+  gui_destroy(context);
   return NULL;
 }
 void gui_receive_message(void *gc, jnx_guid *session_guid, jnx_char *message) {
   gui_context_t *c = (gui_context_t *) gc;
-  display_remote_message(c, message);
+  if (c->s->is_connected) {
+    display_remote_message(c, message);
+  }
+  else {
+    gui_destroy(c);
+  }
 }

--- a/src/gui/gui.c
+++ b/src/gui/gui.c
@@ -57,8 +57,8 @@ gui_context_t *gui_create(session *s) {
   display_logo();
   ui->screen = newwin(LINES - 6, COLS - 1, 1, 1);
   scrollok(ui->screen, TRUE);
-  //  box(ui->screen, 0, 0);
-  wborder(ui->screen, '|', '|', '-', '-', '+', '+', '+', '+');
+  box(ui->screen, 0, 0);
+//  wborder(ui->screen, '|', '|', '-', '-', '+', '+', '+', '+');
   ui->next_line = 1;
   wrefresh(ui->screen);
   ui->prompt = newwin(4, COLS - 1, LINES - 5, 1);

--- a/src/gui/gui.c
+++ b/src/gui/gui.c
@@ -133,9 +133,6 @@ void *read_loop(void *data) {
       if (SESSION_STATE_OKAY == res) {
         display_local_message(context, msg);
       }
-      else {
-        break;
-      }
     }
   }
   session_disconnect(context->s);
@@ -152,6 +149,7 @@ void gui_receive_message(void *gc, jnx_guid *session_guid, jnx_char *message) {
     display_remote_message(c, message);
   }
   else {
+    session_disconnect(c->s);
     display_alert_message(c, message);
   }
 }

--- a/src/gui/gui.c
+++ b/src/gui/gui.c
@@ -114,7 +114,7 @@ void display_local_message(gui_context_t *c, char *msg) {
   free(msg);
 }
 void display_remote_message(gui_context_t *c, char *msg) {
-  display_message(c->ui, msg + 2, COL_REMOTE);
+  display_message(c->ui, msg, COL_REMOTE);
   free(msg);
 }
 void signal_message() {
@@ -154,6 +154,7 @@ void *read_loop(void *data) {
 }
 void gui_receive_message(void *gc, jnx_guid *session_guid, jnx_char *message) {
   gui_context_t *c = (gui_context_t *) gc;
+  printf("[DEBUG] %s", message);
   display_remote_message(c, message);
 }
 int output_next_message_in_context(gui_context_t *context) {

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -32,6 +32,7 @@ typedef struct {
   ui_t *ui;
   session *s;
   char *msg;
+  int is_active;
 } gui_context_t;
 
 gui_context_t *gui_create(session *s);

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -41,6 +41,5 @@ void display_local_message(gui_context_t *c, char *msg);
 void display_remote_message(gui_context_t *c, char *msg);
 void *read_loop(void *data);
 void gui_receive_message(void *gc, jnx_guid *session_guid, jnx_char *message);
-//int output_next_message_in_context(gui_context_t *c);
 
 #endif

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -41,6 +41,6 @@ void display_local_message(gui_context_t *c, char *msg);
 void display_remote_message(gui_context_t *c, char *msg);
 void *read_loop(void *data);
 void gui_receive_message(void *gc, jnx_guid *session_guid, jnx_char *message);
-int output_next_message_in_context(gui_context_t *c);
+//int output_next_message_in_context(gui_context_t *c);
 
 #endif

--- a/src/net/auth_comms.c
+++ b/src/net/auth_comms.c
@@ -57,10 +57,11 @@ static jnx_int32 listener_callback(jnx_uint8 *payload,
      */
     if(a->is_requesting_public_key && !a->is_requesting_finish){
 
-      jnx_guid g;
+      jnx_guid g, session_g;
       jnx_guid_from_string(a->initiator_guid,&g);
-      
-      abort_token = t->ac->ar_callback(t->ds,&g);
+      jnx_guid_from_string(a->session_guid,&session_g);
+
+      abort_token = t->ac->ar_callback(t->ds,&g,&session_g);
 
       printf("Did receive handshake request.\n");
       session *osession;

--- a/src/net/auth_comms.h
+++ b/src/net/auth_comms.h
@@ -13,7 +13,7 @@
 #include "../session/session_service.h"
 #include <jnxc_headers/jnxthread.h>
 
-typedef int (*accept_reject_callback)(discovery_service *, jnx_guid *);
+typedef int (*accept_reject_callback)(discovery_service *, jnx_guid *, jnx_guid *);
 
 typedef struct auth_comms_service {
   jnx_socket *listener_socket;

--- a/src/net/secure_comms.c
+++ b/src/net/secure_comms.c
@@ -84,7 +84,7 @@ void *secure_comms_bootstrap_listener(void *args) {
     else if (bytes_read == 0) {
       // the other side has closed the chat
       session_disconnect(s);
-      s->session_callback(s->gui_context, &s->session_guid, "The chat has terminated.");
+      s->session_callback(s->gui_context, &s->session_guid, "The chat has terminated. Type :q to end the session.");
       break;
     }
   }

--- a/src/net/secure_comms.c
+++ b/src/net/secure_comms.c
@@ -81,10 +81,11 @@ void *secure_comms_bootstrap_listener(void *args) {
 
       s->session_callback(s->gui_context, &s->session_guid, decrypted_message);
     }
-    else {
+    else if (bytes_read == 0) {
+      // the other side has closed the chat
       session_disconnect(s);
-      s->is_connected = 0;
       s->session_callback(s->gui_context, &s->session_guid, "The chat has terminated.");
+      break;
     }
   }
   return NULL;

--- a/src/net/secure_comms.c
+++ b/src/net/secure_comms.c
@@ -73,8 +73,8 @@ void *secure_comms_bootstrap_listener(void *args) {
   jnx_char buffer[2048];
   while(s->is_connected) {
     bzero(buffer,2048);
-    int bytes_read = read(s->secure_comms_fd,
-        buffer,2048);
+    int bytes_read = recv(s->secure_comms_fd,
+        buffer,2048, 0);
     printf("Bytes read = %d\n", bytes_read);
     if (bytes_read > 0) { 
       jnx_char *decrypted_message = 

--- a/src/net/secure_comms.c
+++ b/src/net/secure_comms.c
@@ -59,7 +59,7 @@ static int connect_for_socket_fd(jnx_socket *s, peer *remote_peer,session *ses) 
   }
   if(!s->isconnected) {
     if(connect(s->socket,res->ai_addr,res->ai_addrlen) != 0) {
-      perror("connect:");
+      perror("connect");
       freeaddrinfo(res);
       return 1;
     }
@@ -74,13 +74,16 @@ void *secure_comms_bootstrap_listener(void *args) {
   while(s->is_connected) {
     bzero(buffer,2048);
     jnx_size bytes_read = read(s->secure_comms_fd,
-    buffer,2048);
-   
-    jnx_char *decrypted_message = 
-      symmetrical_decrypt(s->shared_secret,buffer,strlen(buffer));
-    
-    s->session_callback(s->gui_context, &s->session_guid, decrypted_message);
+        buffer,2048);
+
+    if (bytes_read > 0) { 
+      jnx_char *decrypted_message = 
+        symmetrical_decrypt(s->shared_secret,buffer,strlen(buffer));
+
+      s->session_callback(s->gui_context, &s->session_guid, decrypted_message);
+    }
   }
+  return NULL;
 }
 void secure_comms_start(secure_comms_endpoint e, discovery_service *ds,
     session *s,jnx_unsigned_int addr_family) {

--- a/src/net/secure_comms.c
+++ b/src/net/secure_comms.c
@@ -73,14 +73,18 @@ void *secure_comms_bootstrap_listener(void *args) {
   jnx_char buffer[2048];
   while(s->is_connected) {
     bzero(buffer,2048);
-    jnx_size bytes_read = read(s->secure_comms_fd,
+    int bytes_read = read(s->secure_comms_fd,
         buffer,2048);
-
+    printf("Bytes read = %d\n", bytes_read);
     if (bytes_read > 0) { 
       jnx_char *decrypted_message = 
         symmetrical_decrypt(s->shared_secret,buffer,strlen(buffer));
 
       s->session_callback(s->gui_context, &s->session_guid, decrypted_message);
+    }
+    else {
+      session_disconnect(s);
+      s->is_connected = 0;
     }
   }
   return NULL;

--- a/src/net/secure_comms.c
+++ b/src/net/secure_comms.c
@@ -75,7 +75,6 @@ void *secure_comms_bootstrap_listener(void *args) {
     bzero(buffer,2048);
     int bytes_read = recv(s->secure_comms_fd,
         buffer,2048, 0);
-    printf("Bytes read = %d\n", bytes_read);
     if (bytes_read > 0) { 
       jnx_char *decrypted_message = 
         symmetrical_decrypt(s->shared_secret,buffer,strlen(buffer));
@@ -85,6 +84,7 @@ void *secure_comms_bootstrap_listener(void *args) {
     else {
       session_disconnect(s);
       s->is_connected = 0;
+      s->session_callback(s->gui_context, &s->session_guid, "The chat has terminated.");
     }
   }
   return NULL;

--- a/src/session/session.c
+++ b/src/session/session.c
@@ -4,7 +4,7 @@
  *
  * Distributed under terms of the MIT license.
  */
-
+#include <sys/socket.h>
 #include "session.h"
 #include "../gui/gui.h"
 
@@ -20,7 +20,7 @@ session_state session_message_write(session *s,jnx_char *message) {
   jnx_size len = strlen(message);
   jnx_char *encrypted = symmetrical_encrypt(s->shared_secret,message,
       len);
-  if (0 > write(s->secure_comms_fd,encrypted,strlen(encrypted))) {
+  if (0 > send(s->secure_comms_fd,encrypted,strlen(encrypted),0)) {
     session_disconnect(s);
     perror("session: write");
     return SESSION_STATE_FAIL;

--- a/src/session/session.c
+++ b/src/session/session.c
@@ -20,7 +20,11 @@ session_state session_message_write(session *s,jnx_char *message) {
   jnx_size len = strlen(message);
   jnx_char *encrypted = symmetrical_encrypt(s->shared_secret,message,
       len);
-  write(s->secure_comms_fd,encrypted,strlen(encrypted));
+  if (0 > write(s->secure_comms_fd,encrypted,strlen(encrypted))) {
+    session_disconnect(s);
+    perror("session: write");
+    return SESSION_STATE_FAIL;
+  }
   return SESSION_STATE_OKAY;
 }
 session_state session_message_read_and_decrypt(session *s, 

--- a/src/session/session_service.c
+++ b/src/session/session_service.c
@@ -88,7 +88,7 @@ session_state session_service_create_session(session_service *service, session *
   s->receiver_public_key = NULL;
   s->shared_secret = NULL;
   s->secure_comms_fd = 0;
-  s->session_callback = default_session_callback;
+  s->session_callback = NULL;
   s->gui_context = NULL;
   jnx_guid_create(&s->session_guid);
   generate_blank_guid(&s->local_peer_guid); 

--- a/src/session/session_service.c
+++ b/src/session/session_service.c
@@ -110,7 +110,7 @@ session_state session_service_create_shared_session(session_service *service,\
     printf("Returning existing session.\n");
     return e;
   }
-   e = session_service_create_session(service,osession);
+  e = session_service_create_session(service,osession);
   (*osession)->session_guid = g;
   return e;
 }


### PR DESCRIPTION
Well it works for the most part.

I had to change it up a few times, in the end I am just displaying the chat termination message and letting remote peer (the one that hasn't quit the session) type :q to close the session on their end too.

Occasionally it still fails to send session_guid via unix sockets. It was hardly working on Linux but I've changed it to introduce two sockets and using jnxc APIs so now it seems that it works on Linux at least most of the time. Ive started multiple sessions from both Mac to Linux and vice-versa and checked combinations of various quitting and seems to be OK.

Doesn't like it at all when I try to GDB it. Just won't connect the unix sockets. Bizarre...

What doesn't work though is multiple sessions to the same user in the same program run. I haven't looked too deeply into, could be the sessions API could be the GUI. Cross that bridge later - I've spent too much time this weekend mucking round with whisper so can't be bothered to look at it now.

Anyways, give it a spin and report the issues you find.


